### PR TITLE
🧶 Simplified types on par with useCallback, correct handlers return t…

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,7 @@
 ## react-handler-hooks-benchmark
 
 ```bash
+npm run install
 npm run benchmark
 ```
 

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-handler-hooks-benchmark",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "dependencies": {
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
@@ -13,7 +13,7 @@
     "copy-handler-hooks": "node scripts/copy-handler-hooks",
     "serve": "serve build",
     "open": "open-cli http://localhost:5000",
-    "benchmark": "npm install && npm run copy-handler-hooks && npm run build && npm run open && npm run serve"
+    "benchmark": "npm run copy-handler-hooks && npm run build && npm run open && npm run serve"
   },
   "devDependencies": {
     "@types/node": "^12.12.28",

--- a/benchmark/src/App.tsx
+++ b/benchmark/src/App.tsx
@@ -1,9 +1,10 @@
-import React, {FC, memo, useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
+import React, {FC, memo, useEffect, useState} from 'react';
 import Controls from './components/Controls';
 import {BenchmarkProps} from './models/benchmarkProps';
 import {Benchmarks} from './benchmarks';
 import Results from './components/Results';
 import Notes from './components/Notes';
+import {useHandler} from './hooks/useHandler';
 
 const App: FC = () => {
 
@@ -14,15 +15,7 @@ const App: FC = () => {
 
   const [isRunning, setIsRunning] = useState(false);
   const [currentBenchmark, setCurrentBenchmark] = useState(0);
-  const currentBenchmarkRef = useRef(currentBenchmark);
-
   const [results, setResults] = useState<Array<Array<number>>>([]);
-  const resultsRef = useRef(results);
-
-  useLayoutEffect(() => {
-    currentBenchmarkRef.current = currentBenchmark;
-    resultsRef.current = results;
-  });
 
   useEffect(
     () => {
@@ -31,29 +24,23 @@ const App: FC = () => {
     [nodesCount, childrenCount, renderCount, callbackCount]
   );
 
-  const onStart = useCallback(
-    () => {
-      setIsRunning(true);
-      setCurrentBenchmark(0);
-      setResults([...resultsRef.current, []]);
-    },
-    []
-  );
+  const onStart = useHandler(() => {
+    setIsRunning(true);
+    setCurrentBenchmark(0);
+    setResults([...results, []]);
+  });
 
-  const onFinish = useCallback(
-    (ms: number) => {
-      let resultsRow = resultsRef.current[resultsRef.current.length - 1];
-      resultsRow = [...resultsRow, Math.round(ms)];
-      const newResults = [...resultsRef.current.slice(0, resultsRef.current.length - 1), resultsRow];
-      setResults(newResults);
-      if (currentBenchmarkRef.current >= Benchmarks.length - 1) {
-        setIsRunning(false);
-      } else {
-        setCurrentBenchmark(currentBenchmarkRef.current + 1);
-      }
-    },
-    []
-  );
+  const onFinish = useHandler((ms: number) => {
+    let resultsRow = results[results.length - 1];
+    resultsRow = [...resultsRow, Math.round(ms)];
+    const newResults = [...results.slice(0, results.length - 1), resultsRow];
+    setResults(newResults);
+    if (currentBenchmark >= Benchmarks.length - 1) {
+      setIsRunning(false);
+    } else {
+      setCurrentBenchmark(currentBenchmark + 1);
+    }
+  });
 
   const benchmarkProps: BenchmarkProps = {
     nodesCount,

--- a/benchmark/src/benchmarks/BenchmarkUseHandler.tsx
+++ b/benchmark/src/benchmarks/BenchmarkUseHandler.tsx
@@ -7,9 +7,8 @@ import {useHandler} from '../hooks/useHandler';
 const BenchmarkUseHandler: FC<BenchmarkProps> = props => {
   const tools = useBenchmark(props);
 
-  const callback = useHandler<string, number, boolean, HTMLDivElement>(
-    (a, b, c, element) => {}
-  );
+  const callback = useHandler((a: string, b: number, c: boolean, element: HTMLDivElement) => {
+  });
 
   return (
     <>

--- a/benchmark/src/benchmarks/BenchmarkUseParamsHandler.tsx
+++ b/benchmark/src/benchmarks/BenchmarkUseParamsHandler.tsx
@@ -7,9 +7,8 @@ import {useParamsHandler} from '../hooks/useParamsHandler';
 const BenchmarkUseParamsHandler: FC<BenchmarkProps> = props => {
   const tools = useBenchmark(props);
 
-  const callback = useParamsHandler<Key, [string, number, boolean, HTMLDivElement]>(
-    (key: Key, a, b, c, element) => {}
-  );
+  const callback = useParamsHandler((key: Key, a: string, b: number, c: boolean, element: HTMLDivElement) => {
+  });
 
   return (
     <>

--- a/benchmark/src/components/Child.tsx
+++ b/benchmark/src/components/Child.tsx
@@ -1,4 +1,4 @@
-import React, {FC, memo, useEffect, useLayoutEffect, useMemo, useRef} from 'react';
+import React, {FC, memo, useEffect, useMemo, useRef} from 'react';
 import Node from './Node';
 
 interface Props extends React.HTMLProps<HTMLDivElement> {
@@ -12,9 +12,7 @@ const Child: FC<Props> = ({ nodeCount, callback, callbackTrigger, ...divProps })
   const divRef = useRef<HTMLDivElement>(null);
 
   const callbackRef = useRef(callback);
-  useLayoutEffect(() => {
-    callbackRef.current = callback
-  });
+  callbackRef.current = callback;
 
   useEffect(
     () => {

--- a/benchmark/src/components/NumberInput.tsx
+++ b/benchmark/src/components/NumberInput.tsx
@@ -1,4 +1,5 @@
-import React, { FC, memo, useCallback } from 'react';
+import React, { FC, memo } from 'react';
+import {useHandler} from '../hooks/useHandler';
 
 interface Props {
   value: number;
@@ -9,12 +10,9 @@ interface Props {
 
 const NumberInput: FC<Props> = props => {
 
-  const onInputChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onInputChange = useHandler((event: React.ChangeEvent<HTMLInputElement>) => {
       props.onChange(Math.floor(Number.parseFloat(event.target.value)));
-    },
-    [props.onChange]
-  );
+  });
 
   return (
     <label>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-handler-hooks",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "React hooks for persistent and parameterizable callbacks",
   "author": {
     "url": "https://github.com/ArielJurkowski",
@@ -22,10 +22,12 @@
   },
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watchAll",
+    "test:watch": "jest --watch",
     "build": "tsc"
   },
   "keywords": [
+    "react",
+    "reactjs",
     "hook",
     "hooks",
     "handler",
@@ -39,7 +41,9 @@
     "param",
     "params",
     "parameters",
-    "persistent"
+    "persistent",
+    "typescript",
+    "typed"
   ],
   "files": [
     "dist"

--- a/src/useHandler.ts
+++ b/src/useHandler.ts
@@ -1,18 +1,10 @@
-import {useCallback, useRef} from "react";
+import {DependencyList, useCallback, useRef} from 'react';
 
-export function useHandler(callback: () => any): () => any;
-export function useHandler<T1>(callback: (...args: [T1]) => any): (...args: [T1]) => any;
-export function useHandler<T1, T2>(callback: (...args: [T1, T2]) => any): (...args: [T1, T2]) => any;
-export function useHandler<T1, T2, T3>(callback: (...args: [T1, T2, T3]) => any): (...args: [T1, T2, T3]) => any;
-export function useHandler<T1, T2, T3, T4>(callback: (...args: [T1, T2, T3, T4]) => any): (...args: [T1, T2, T3, T4]) => any;
-export function useHandler<T1, T2, T3, T4, T5>(callback: (...args: [T1, T2, T3, T4, T5]) => any): (...args: [T1, T2, T3, T4, T5]) => any;
-export function useHandler<T1, T2, T3, T4, T5, T6>(callback: (...args: [T1, T2, T3, T4, T5, T6]) => any): (...args: [T1, T2, T3, T4, T5, T6]) => any;
-export function useHandler<T1, T2, T3, T4, T5, T6, T7>(callback: (...args: [T1, T2, T3, T4, T5, T6, T7]) => any): (...args: [T1, T2, T3, T4, T5, T6, T7]) => any;
-export function useHandler(callback: (...args: any[]) => any) {
+export function useHandler<T extends (...args: any[]) => any>(callback: T, deps: DependencyList = []): T {
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
   return useCallback(
     (...args: any[]) => callbackRef.current(...args),
-    []
-  );
+    deps
+  ) as T;
 }


### PR DESCRIPTION
…ypes instead of any, optional deplist, using handlers in the project itself, more tests, infinite params support